### PR TITLE
fix: avoid to brake download with very long episode title

### DIFF
--- a/scripts/python/converter.py
+++ b/scripts/python/converter.py
@@ -13,7 +13,7 @@ import utils
 
 class Subtitles:
     def __init__(self, output, language):
-        self.output = output
+        self.output = output[:251]
         self.language = language
 
     def download(self, subtitles_url):

--- a/scripts/python/downloader.py
+++ b/scripts/python/downloader.py
@@ -78,6 +78,7 @@ class crunchyroll:
         (video_url, subtitles_url, audio_language) = extractor.download_url(r, self.config, all_subs)
         (type, id) = utils.get_download_type(r)
         (metadata, cover, thumbnail, output, path) = extractor.get_metadata(type, id, self.config)
+        output = output[:251]
         utils.create_folder(path)
 
         already_downloaded = False


### PR DESCRIPTION
limit the filename to 251 chars (limit is 255, 251 + 4 ( .ext )) otherwise it brakes creating subtitles and video files with a filename too long error